### PR TITLE
Fix import error: No module named multiq

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,10 +7,10 @@ import copy
 from pathlib import Path
 
 
-from multiq import structures, DEVICE
-from multiq.trainer import Trainer
-from multiq.structures import Actor, Critic, RescaleAction
-from multiq.functions import eval_policy
+from tqc import structures, DEVICE
+from tqc.trainer import Trainer
+from tqc.structures import Actor, Critic, RescaleAction
+from tqc.functions import eval_policy
 
 
 EPISODE_LENGTH = 1000

--- a/tqc/functions.py
+++ b/tqc/functions.py
@@ -1,6 +1,6 @@
 import torch
 
-from multiq import DEVICE
+from tqc import DEVICE
 
 
 def eval_policy(policy, eval_env, max_episode_steps, eval_episodes=10):

--- a/tqc/structures.py
+++ b/tqc/structures.py
@@ -7,7 +7,7 @@ from gym import spaces
 import gym
 
 
-from multiq import DEVICE
+from tqc import DEVICE
 
 
 LOG_STD_MIN_MAX = (-20, 2)

--- a/tqc/trainer.py
+++ b/tqc/trainer.py
@@ -1,7 +1,7 @@
 import torch
 
-from multiq.functions import quantile_huber_loss_f
-from multiq import DEVICE
+from tqc.functions import quantile_huber_loss_f
+from tqc import DEVICE
 
 
 class Trainer(object):


### PR DESCRIPTION
At first, thank you very much for a pytorch implementation!

I've faced some import errors, when importing `multiq` package and changed all files to import `tqc`.

Could be related to your changes introduced in d6554ba4cf152fc756ba6d119bad0778141ff625, in which you removed `multiq` from python path. 



